### PR TITLE
use getaddrinfo to correctly support both IPv4 and IPv6

### DIFF
--- a/asyncmc/host.py
+++ b/asyncmc/host.py
@@ -22,9 +22,11 @@ class Host(object):
         self.deaduntil = 0
 
         if ":" in self.host:
-            parts = self.host.split(":")
+            parts = self.host.rsplit(":", 1)
             self.host = parts[0]
             self.port = int(parts[1])
+        if self.host.startswith('[') and self.host.endswith(']'):
+            self.host = self.host[1:-1]
 
         self.sock = None
 
@@ -32,18 +34,34 @@ class Host(object):
         if self.sock:
             return self
 
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        if hasattr(s, 'settimeout'):
-            s.settimeout(constants.SOCKET_TIMEOUT)
-        try:
-            s.connect((self.host, self.port))
-        except socket.timeout as msg:
-            self.mark_dead('connect: {}'.format(msg))
-            return None
-        except socket.error as msg:
-            if isinstance(msg, tuple):
-                msg = msg[1]
-            self.mark_dead('connect: {}'.format(msg))
+        remaining = constants.SOCKET_TIMEOUT
+        last_error = None
+
+        for family, socktype, proto, _, addr in socket.getaddrinfo(
+            self.host, self.port, socket.AF_UNSPEC, socket.SOCK_STREAM
+        ):
+            if not remaining:
+                self.mark_dead('connect: no time left')
+                return None
+            try:
+                s = socket.socket(family, socktype, proto)
+                s.settimeout(remaining)
+                start = time.time()
+                s.connect(addr)
+                break
+            except socket.timeout as msg:
+                self.mark_dead('connect: {}'.format(msg))
+                return None
+            except socket.error as msg:
+                if isinstance(msg, tuple):
+                    msg = msg[1]
+                last_error = msg
+                s.close()
+                duration = time.time() - start
+                remaining = max(remaining - duration, 0)
+        else:
+            # if we never broke out of the getaddr loop
+            self.mark_dead('connect: {}'.format(last_error))
             return None
         self.sock = s
         self.stream = tornado.iostream.IOStream(s)


### PR DESCRIPTION
This allows you to specify IPv6 literals, as long as you have a port (e.g., `[::1]:11211` or even `::1:11211`). On most systems, it will also follow the rules in [RFC 6724](https://tools.ietf.org/html/rfc6724) to correctly resolve hostnames to their IPv6 or IPv4 addresses, depending on reachability and precendence rules.

The big caveat:

I have been told `getaddrinfo` either doesn't exist or doesn't work on Windows when contributing similar patches to other projects. I assume that nobody is using asyncmc on Windows (which would already be rather painful anyway), but if anyone is, then we might have to conditionalize this whole function on whether or not `socket.getaddrinfo` is present... or, at least, we'd need someone with a Windows install to test this before merging to master.