### PR TITLE
Handle case where response includes server name

### DIFF
--- a/asyncmc/client.py
+++ b/asyncmc/client.py
@@ -149,7 +149,7 @@ class Client(object):
         response = yield conn.send_cmd(command)
         if not response.startswith(const.VERSION):
             raise ClientException('Memcached version failed', response)
-        version, number = response.split()
+        version, number = response.split()[:2]
         raise gen.Return(number)
 
     def _key_type(self, key_list=[], key=None):


### PR DESCRIPTION
In my local usage of this I get the following output when using telnet:

```
Connected to localhost.
Escape character is '^]'.
version
VERSION 1.4.25 Ubuntu
```

Which I see as an exception in the client. This patch keeps current
behavior, but allows there to be more on the line.