### PR TITLE
conditionalize toro input and use native asyncio Queue class on modern python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pep8
-tornado==4.1
+tornado==5.0
 pycodestyle==2.3.1
 pyflakes
-toro==0.8
+toro==0.8;python_version < 3.0

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,17 @@ from setuptools import setup, find_packages
 
 version = '0.6.7'
 
+
 def read(f):
     return open(os.path.join(os.path.dirname(__file__), f)).read().strip()
 
+
 install_requires = [
-    'tornado>=4.1',
-    'toro>=0.8'
+    'tornado>=5.0',
 ]
+
+if sys.version_info < (3, 0):
+    install_requires.append('toro >= 0.8')
 
 setup(name='asyncmc',
       version=version,
@@ -32,5 +36,5 @@ setup(name='asyncmc',
       url='https://github.com/ErDmKo/asyncmc/',
       license='MIT',
       packages=find_packages(),
-      install_requires = install_requires,
-      include_package_data = True)
+      install_requires=install_requires,
+      include_package_data=True)


### PR DESCRIPTION
toro relies on the setuptools  2to3 helper, which is gone in current setuptools

just use native `asyncio.Queue` instead on Python 3.x

Fixes #12 